### PR TITLE
Add support for a relay server

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+tusharhero <tusharhero@sdf.org>
+virinci <revirinci@proton.me>

--- a/nettactoe
+++ b/nettactoe
@@ -138,6 +138,15 @@ function restart_game {
     fi
 }
 
+function toss {
+    if [ "$player_no" -eq 0 ]; then
+        move_no=$((RANDOM % 2))
+        stdbuf -oL echo "$move_no" >&"${CONN[1]}"
+    else
+        read -r move_no <&"${CONN[0]}"
+    fi
+}
+
 function server {
     read -rp "Enter the IP address of the nettactoe server (enter self to host it yourself): " -i "self" -e server_ip
     read -rp "Enter the port of nettactoe server (or the port to use for the nettactoe server): " -i "4444" -e server_port

--- a/nettactoe
+++ b/nettactoe
@@ -142,7 +142,7 @@ function restart_game {
 function toss {
     if [ "$player_no" -eq 0 ]; then
         move_no=$((RANDOM % 2))
-        stdbuf -oL echo "$move_no" >&"${CONN[1]}"
+        echo "$move_no" >&"${CONN[1]}"
     else
         read -r move_no <&"${CONN[0]}"
     fi
@@ -150,14 +150,14 @@ function toss {
 
 function server {
     read -rp "Enter the port of the nettactoe server: " -i "4444" -e server_port
-    coproc CONN { stdbuf -oL nc -l -p "$server_port"; }
+    coproc CONN { nc -l -p "$server_port"; }
 
     # Read the dummy secret phrase sent by the client.
     # It isn't used because there is no intermediate relay server.
     read -r <&"${CONN[0]}"
 
     # Make the other player Player 0.
-    stdbuf -oL echo '0' >&"${CONN[1]}"
+    echo '0' >&"${CONN[1]}"
     player_no=1
 
     client nope
@@ -169,10 +169,10 @@ function client {
         read -rp "Enter the port of the nettactoe server: " -i "4444" -e server_port
         read -rp "Enter the shared secret phrase: " -e secret
 
-        coproc CONN { stdbuf -oL nc "$server_ip" "$server_port"; }
-        sleep 3
+        coproc CONN { nc "$server_ip" "$server_port"; }
+        # sleep 3
 
-        stdbuf -oL echo "$secret" >&"${CONN[1]}"
+        echo "$secret" >&"${CONN[1]}"
 
         # Get the player_no. Player 0 is O and 1 is X.
         read -r player_no <&"${CONN[0]}"

--- a/nettactoe
+++ b/nettactoe
@@ -188,38 +188,42 @@ function server {
 }
 
 function client {
-    read -rp "Enter the IP address of the nettactoe server: " -i "localhost" -e server_ip
-    read -rp "Enter the port of the nettactoe server: " -i "4444" -e server_port
-    read -rp "Enter the shared secret phrase: " -e secret
+    if [ "$#" = 0 ]; then
+        read -rp "Enter the IP address of the nettactoe server: " -i "localhost" -e server_ip
+        read -rp "Enter the port of the nettactoe server: " -i "4444" -e server_port
+        read -rp "Enter the shared secret phrase: " -e secret
 
-    coproc CLIENT { stdbuf -oL nc "$server_ip" "$server_port"; }
-    sleep 3
-    stdbuf -oL echo "$secret" >&"${CLIENT[1]}"
+        coproc CONN { stdbuf -oL nc "$server_ip" "$server_port"; }
+        sleep 3
 
-    # Send the connected message and receive acknowledgement.
-    stdbuf -oL echo "Connected" >&"${CLIENT[1]}"
-    read -r <&"${CLIENT[0]}"
+        stdbuf -oL echo "$secret" >&"${CONN[1]}"
 
-    no_moves=0
+        # Get the player_no. Player 0 is O and 1 is X.
+        read -r player_no <&"${CONN[0]}"
+    fi
+
+    toss
+    game="$NEW_GAME"
 
     while true; do
-        read -r game <&"${CLIENT[0]}"
         clear
         render_array "$game"
 
         result=$(check_game "$game")
         restart_game
 
-        player=$( ((no_moves % 2 == 0)) && echo "⭕" || echo "❌" )
-        if [ "$player" = "❌" ]; then
+        player=$( ((move_no % 2 == 0)) && echo "⭕" || echo "❌" )
+
+        if [ $((move_no % 2)) = "$player_no" ]; then
             read -rp "$player Enter move: " move
             game=$(make_move "$game" "$player" "$move");
-            echo "$game" >&"${CLIENT[1]}"
+            echo "$game" >&"${CONN[1]}"
         else
-            echo "Waiting for ⭕ to make a move"
+            echo "Waiting for $player to make a move"
+            read -r game <&"${CONN[0]}"
         fi
 
-        no_moves=$((no_moves + 1))
+        move_no=$((move_no + 1))
     done
 }
 
@@ -236,6 +240,8 @@ function splash_screen {
     read -r
     clear
 }
+
+NEW_GAME="⬛,⬛,⬛️;⬛️,⬛️,⬛️;⬛️,⬛️,⬛️"
 
 splash_screen
 

--- a/nettactoe
+++ b/nettactoe
@@ -32,11 +32,11 @@ function min {
 
 function clamp {
     if [ "$1" -lt "$2" ]; then
-	echo "$2"
+        echo "$2"
     elif [ "$1" -gt "$3" ]; then
-	echo "$3"
+        echo "$3"
     else
-	echo "$1"
+        echo "$1"
     fi
 }
 
@@ -149,23 +149,23 @@ function server {
     no_moves=0
 
     while true; do
-	clear
-	render_array "$game"
-	echo "$game" >&"${SERVER[1]}"
+        clear
+        render_array "$game"
+        echo "$game" >&"${SERVER[1]}"
 
-	result=$(check_game "$game")
-	restart_game
+        result=$(check_game "$game")
+        restart_game
 
-	player=$( ((no_moves % 2 == 0)) && echo "⭕" || echo "❌" )
-	if [ "$player" = "⭕" ]; then
-	    read -rp "$player Enter move: " move
-	    game=$(make_move "$game" "$player" "$move");
-	else
-	    echo "Waiting for ❌ to make a move"
-	    read -r game <&"${SERVER[0]}"
-	fi
+        player=$( ((no_moves % 2 == 0)) && echo "⭕" || echo "❌" )
+        if [ "$player" = "⭕" ]; then
+            read -rp "$player Enter move: " move
+            game=$(make_move "$game" "$player" "$move");
+        else
+            echo "Waiting for ❌ to make a move"
+            read -r game <&"${SERVER[0]}"
+        fi
 
-	no_moves=$((no_moves + 1))
+        no_moves=$((no_moves + 1))
     done
 }
 
@@ -177,23 +177,23 @@ function client {
     no_moves=0
 
     while true; do
-	read -r game <&"${CLIENT[0]}"
-	clear
-	render_array "$game"
+        read -r game <&"${CLIENT[0]}"
+        clear
+        render_array "$game"
 
-	result=$(check_game "$game")
-	restart_game
+        result=$(check_game "$game")
+        restart_game
 
-	player=$( ((no_moves % 2 == 0)) && echo "⭕" || echo "❌" )
-	if [ "$player" = "❌" ]; then
-	    read -rp "$player Enter move: " move
-	    game=$(make_move "$game" "$player" "$move");
-	    echo "$game" >&"${CLIENT[1]}"
-	else
-	    echo "Waiting for ⭕ to make a move"
-	fi
+        player=$( ((no_moves % 2 == 0)) && echo "⭕" || echo "❌" )
+        if [ "$player" = "❌" ]; then
+            read -rp "$player Enter move: " move
+            game=$(make_move "$game" "$player" "$move");
+            echo "$game" >&"${CLIENT[1]}"
+        else
+            echo "Waiting for ⭕ to make a move"
+        fi
 
-	no_moves=$((no_moves + 1))
+        no_moves=$((no_moves + 1))
     done
 }
 

--- a/nettactoe
+++ b/nettactoe
@@ -154,6 +154,7 @@ function server {
 
     # Read the dummy secret phrase sent by the client.
     # It isn't used because there is no intermediate relay server.
+    echo 'Waiting for the other player to join...'
     read -r <&"${CONN[0]}"
 
     # Make the other player Player 0.
@@ -170,12 +171,27 @@ function client {
         read -rp "Enter the shared secret phrase: " -e secret
 
         coproc CONN { nc "$server_ip" "$server_port"; }
-        # sleep 3
+
+        echo 'Connecting to the server...'
+        sleep 3
 
         echo "$secret" >&"${CONN[1]}"
 
         # Get the player_no. Player 0 is O and 1 is X.
         read -r player_no <&"${CONN[0]}"
+    fi
+
+    # Prevent early start of player 0 by synchronizing both the players.
+    if [ "$player_no" -eq 0 ]; then
+        echo 'Waiting for the other player to join...'
+        read -r <&"${CONN[0]}"
+
+        echo 'ACK' >&"${CONN[1]}"
+    else
+        echo 'ACK' >&"${CONN[1]}"
+
+        echo 'Waiting for the other player to join...'
+        read -r <&"${CONN[0]}"
     fi
 
     toss

--- a/nettactoe
+++ b/nettactoe
@@ -122,19 +122,20 @@ function make_move {
 }
 
 function restart_game {
-
     [ -z "$result" ] && return 0
+
     clear
     render_array "$game"
     echo "$result" won!
+
     read -rp 'Do you want to play again? [y/N] ' restart
 
     if [ "$restart" == 'Y' ] || [ "$restart" == 'y' ]; then
-	echo 'restarting game!'
-	game="$new_game"
-	no_moves=0
+        echo 'Restarting game!'
+        game="$NEW_GAME"
+        toss
     else
-	exit
+        exit
     fi
 }
 
@@ -181,11 +182,11 @@ function client {
     game="$NEW_GAME"
 
     while true; do
-        clear
-        render_array "$game"
-
         result=$(check_game "$game")
         restart_game
+
+        clear
+        render_array "$game"
 
         player=$( ((move_no % 2 == 0)) && echo "⭕" || echo "❌" )
 

--- a/nettactoe
+++ b/nettactoe
@@ -139,11 +139,29 @@ function restart_game {
 }
 
 function server {
-    read -p "Enter the port to use for the nettactoe server: " -i "4444" -e server_port
-    coproc SERVER { nc -l -p $server_port ; }
+    read -rp "Enter the IP address of the nettactoe server (enter self to host it yourself): " -i "self" -e server_ip
+    read -rp "Enter the port of nettactoe server (or the port to use for the nettactoe server): " -i "4444" -e server_port
+
+    if [ "$server_ip" = 'self' ]; then
+        coproc SERVER { stdbuf -oL nc -l -p $server_port ; }
+
+        # Read the dummy secret phrase sent by the client.
+        # It isn't used because there is no intermediate relay server.
+        read <&"${SERVER[0]}"
+    else
+        read -rp "Enter the shared secret phrase: " -e secret
+        coproc SERVER { stdbuf -oL nc "$server_ip" "$server_port"; }
+        sleep 3
+        stdbuf -oL echo "$secret" >&"${SERVER[1]}"
+    fi
+
+    # Read the connected message from client and send acknowledgement.
     echo "Waiting for a client to join.."
     read <&"${SERVER[0]}"
-    echo "client has joined!"
+
+    echo "Client has joined!"
+    stdbuf -oL echo 'You joined' >&"${SERVER[1]}"
+
     new_game="⬛,⬛,⬛️;⬛️,⬛️,⬛️;⬛️,⬛️,⬛️"
     game="$new_game"
     no_moves=0
@@ -170,10 +188,18 @@ function server {
 }
 
 function client {
-    read -p "Enter the IP address of the server: " -i "localhost" -e server_ip
-    read -p "Enter the port of nettactoe server: " -i "4444" -e server_port
-    coproc CLIENT { nc $server_ip $server_port; }
-    echo "Connected" >&"${CLIENT[1]}"
+    read -rp "Enter the IP address of the nettactoe server: " -i "localhost" -e server_ip
+    read -rp "Enter the port of the nettactoe server: " -i "4444" -e server_port
+    read -rp "Enter the shared secret phrase: " -e secret
+
+    coproc CLIENT { stdbuf -oL nc "$server_ip" "$server_port"; }
+    sleep 3
+    stdbuf -oL echo "$secret" >&"${CLIENT[1]}"
+
+    # Send the connected message and receive acknowledgement.
+    stdbuf -oL echo "Connected" >&"${CLIENT[1]}"
+    read -r <&"${CLIENT[0]}"
+
     no_moves=0
 
     while true; do

--- a/nettactoe
+++ b/nettactoe
@@ -148,52 +148,18 @@ function toss {
 }
 
 function server {
-    read -rp "Enter the IP address of the nettactoe server (enter self to host it yourself): " -i "self" -e server_ip
-    read -rp "Enter the port of nettactoe server (or the port to use for the nettactoe server): " -i "4444" -e server_port
+    read -rp "Enter the port of the nettactoe server: " -i "4444" -e server_port
+    coproc CONN { stdbuf -oL nc -l -p "$server_port"; }
 
-    if [ "$server_ip" = 'self' ]; then
-        coproc SERVER { stdbuf -oL nc -l -p $server_port ; }
+    # Read the dummy secret phrase sent by the client.
+    # It isn't used because there is no intermediate relay server.
+    read -r <&"${CONN[0]}"
 
-        # Read the dummy secret phrase sent by the client.
-        # It isn't used because there is no intermediate relay server.
-        read <&"${SERVER[0]}"
-    else
-        read -rp "Enter the shared secret phrase: " -e secret
-        coproc SERVER { stdbuf -oL nc "$server_ip" "$server_port"; }
-        sleep 3
-        stdbuf -oL echo "$secret" >&"${SERVER[1]}"
-    fi
+    # Make the other player Player 0.
+    stdbuf -oL echo '0' >&"${CONN[1]}"
+    player_no=1
 
-    # Read the connected message from client and send acknowledgement.
-    echo "Waiting for a client to join.."
-    read <&"${SERVER[0]}"
-
-    echo "Client has joined!"
-    stdbuf -oL echo 'You joined' >&"${SERVER[1]}"
-
-    new_game="⬛,⬛,⬛️;⬛️,⬛️,⬛️;⬛️,⬛️,⬛️"
-    game="$new_game"
-    no_moves=0
-
-    while true; do
-        clear
-        render_array "$game"
-        echo "$game" >&"${SERVER[1]}"
-
-        result=$(check_game "$game")
-        restart_game
-
-        player=$( ((no_moves % 2 == 0)) && echo "⭕" || echo "❌" )
-        if [ "$player" = "⭕" ]; then
-            read -rp "$player Enter move: " move
-            game=$(make_move "$game" "$player" "$move");
-        else
-            echo "Waiting for ❌ to make a move"
-            read -r game <&"${SERVER[0]}"
-        fi
-
-        no_moves=$((no_moves + 1))
-    done
+    client nope
 }
 
 function client {

--- a/nettactoe-relay
+++ b/nettactoe-relay
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$MITM_MODE" ] && [ -n "$1" ]; then
+	socat TCP-LISTEN:"$1",fork,reuseaddr,max-children=100 SYSTEM:"MITM_MODE=relay $0 $*"
+elif [ "$MITM_MODE" = 'relay' ]; then
+	secret=$(head -n 1)
+	[ -n "$secret" ] || exit 1
+
+	identifier=$(echo "$secret" | sha256sum | cut -d ' ' -f 1)
+	mkfifo "/tmp/${identifier}-0.fifo" "/tmp/${identifier}-1.fifo" 2> /dev/null
+
+	printf "Secret: '%s'\tFIFO: '%s'\n" "$secret" "$identifier" >&2
+
+	# set -x
+	flock     -x -n "/tmp/${identifier}-0.lock" -c "cat /tmp/${identifier}-1.fifo & cat > /tmp/${identifier}-0.fifo; true" ||
+		flock -x -n "/tmp/${identifier}-1.lock" -c "cat /tmp/${identifier}-0.fifo & cat > /tmp/${identifier}-1.fifo; true" ||
+		exit 1
+else
+	exit 1
+fi

--- a/nettactoe-relay
+++ b/nettactoe-relay
@@ -1,5 +1,21 @@
 #!/bin/sh
 
+# mitm.sh - A general purpose intermediary/relay server for communication between two peers.
+# Copyright (C) 2024 virinci
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 if [ -z "$MITM_MODE" ] && [ -n "$1" ]; then
 	socat TCP-LISTEN:"$1",fork,reuseaddr,max-children=100 SYSTEM:"MITM_MODE=relay $0 $*"
 elif [ "$MITM_MODE" = 'relay' ]; then

--- a/nettactoe-relay
+++ b/nettactoe-relay
@@ -12,8 +12,8 @@ elif [ "$MITM_MODE" = 'relay' ]; then
 	printf "Secret: '%s'\tFIFO: '%s'\n" "$secret" "$identifier" >&2
 
 	# set -x
-	flock     -x -n "/tmp/${identifier}-0.lock" -c "cat /tmp/${identifier}-1.fifo & cat > /tmp/${identifier}-0.fifo; true" ||
-		flock -x -n "/tmp/${identifier}-1.lock" -c "cat /tmp/${identifier}-0.fifo & cat > /tmp/${identifier}-1.fifo; true" ||
+	flock     -x -n "/tmp/${identifier}-0.lock" -c "echo 0; cat /tmp/${identifier}-1.fifo & cat > /tmp/${identifier}-0.fifo; true" ||
+		flock -x -n "/tmp/${identifier}-1.lock" -c "echo 1; cat /tmp/${identifier}-0.fifo & cat > /tmp/${identifier}-1.fifo; true" ||
 		exit 1
 else
 	exit 1


### PR DESCRIPTION
The feature allows players on different networks to play against each other without the need of port forwarding. This is done by running the relay script on a server that already has some port forwarded.
Two players can connect to the same relay server to play against each other. Players are identified using a secret phrase and two players using the same phrase are matched.